### PR TITLE
Make + Docker: Implement arm64 & amd64 native images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,12 @@ test-ci:
 		&& echo \
 		&& echo "Compiling application (apple-darwin x86_64)..." \
 		&& cargo build --release --target x86_64-apple-darwin \
-		&& du -sh target/x86_64-apple-darwin/release/helloworld
+		&& du -sh target/x86_64-apple-darwin/release/helloworld \
+		&& echo \
+		&& echo "Compiling application (apple-darwin aarch64)..." \
+                && cargo build --release --target aarch64-apple-darwin \
+                && du -sh target/aarch64-apple-darwin/release/helloworld
+
 .ONESHELL: test-ci
 
 promote:

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ test-ci:
 	@rustc -vV
 	@echo
 	@cd tests/hello-world \
-		&& echo "Compiling application (linux-musl x86_64)..." \
-		&& cargo build --release --target x86_64-unknown-linux-musl \
-		&& du -sh target/x86_64-unknown-linux-musl/release/helloworld \
-		&& ./target/x86_64-unknown-linux-musl/release/helloworld \
+		&& echo "Compiling application (linux-musl $$(uname -m))..." \
+		&& cargo build --release --target "$$(uname -m)-unknown-linux-musl" \
+		&& du -sh target/$$(uname -m)-unknown-linux-musl/release/helloworld \
+		&& ./target/$$(uname -m)-unknown-linux-musl/release/helloworld \
 		&& echo \
 		&& echo "Compiling application (apple-darwin x86_64)..." \
 		&& cargo build --release --target x86_64-apple-darwin \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,34 @@
+REPOSITORY ?= joseluisq
+TAG ?= latest
+
+
 build:
 	docker build \
-		-t joseluisq/rust-linux-darwin-builder:latest \
+		-t $(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
 		-f docker/Dockerfile .
 .PHONY: build
+
+
+# Use to build both arm64 and amd64 images at the same time.
+# WARNING! Will automatically push, since multi-platform images are not available locally.
+# Use `REPOSITORY` arg to specify which container repository to push the images to.
+buildx:
+	docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
+	docker buildx create --name darwin-builder --driver docker-container --bootstrap
+	docker buildx use darwin-builder
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--push \
+		-t $(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
+		-f docker/Dockerfile .
+
+.PHONY: buildx
 
 test:
 	@docker run --rm -it \
 		-v $(PWD):/drone/src \
 		-w /drone/src \
-			joseluisq/rust-linux-darwin-builder:latest \
+			$(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
 				make test-ci
 .PHONY: test
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ ENV PATH=/root/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/us
 # `--target` to musl so that our users don't need to keep overriding it manually.
 RUN set -eux \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
-    && rustup target add x86_64-unknown-linux-musl \
+    && rustup target add $(uname -m)-unknown-linux-musl \
     && rustup target add armv7-unknown-linux-musleabihf \
     && rustup target add x86_64-apple-darwin \
     && true
@@ -167,9 +167,13 @@ RUN set -eux \
     && true
 
 ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
+    AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_STATIC=1 \
+    AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_STATIC=1 \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
+    PQ_LIB_STATIC_AARCH64_UNKNOWN_LINUX_MUSL=1 \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
+    PG_CONFIG_AARCH64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     LIBZ_SYS_STATIC=1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,6 +94,7 @@ RUN set -eux \
     && rustup target add $(uname -m)-unknown-linux-musl \
     && rustup target add armv7-unknown-linux-musleabihf \
     && rustup target add x86_64-apple-darwin \
+    && rustup target add aarch64-apple-darwin \
     && true
 ADD docker/cargo-config.toml /root/.cargo/config
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,17 +112,23 @@ RUN set -eux \
 # component. It's possible that this will cause bizarre and terrible things to
 # happen. There may be "sanitized" header
 RUN set -eux \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+        amd64) config='';; \
+        arm64) config='-mno-outline-atomics';; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac \
     && echo "Building OpenSSL ${OPENSSL_VERSION}..." \
     && ls /usr/include/linux \
     && mkdir -p /usr/local/musl/include \
     && ln -s /usr/include/linux /usr/local/musl/include/linux \
-    && ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm \
+    && ln -s "/usr/include/$(uname -m)-linux-gnu/asm" /usr/local/musl/include/asm \
     && ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic \
     && cd /tmp \
     && curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" \
     && tar xvzf "openssl-${OPENSSL_VERSION}.tar.gz" \
     && cd "openssl-${OPENSSL_VERSION}" \
-    && env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 \
+    && env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY ${config} "linux-$(uname -m)" \
     && env C_INCLUDE_PATH=/usr/local/musl/include/ make depend \
     && env C_INCLUDE_PATH=/usr/local/musl/include/ make -j$(nproc) \
     && make -j$(nproc) install_sw \

--- a/docker/cargo-config.toml
+++ b/docker/cargo-config.toml
@@ -1,10 +1,20 @@
 [build]
-# Target musl-libc by default when running Cargo.
+# Target musl-libc by default when running Cargo
 target = "x86_64-unknown-linux-musl"
 
 [target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"
+
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin21.4-clang"
 ar = "x86_64-apple-darwin21.4-ar"
+
+[target.aarch64-apple-darwin]
+linker = "arm64e-apple-darwin21.4-clang"
+ar = "arm64e-apple-darwin21.4-ar"


### PR DESCRIPTION
This PR updates the Docker image such that it can be successfully built and used as either a linux/amd64 image or a linux/amd64 image.

The Makefile has been given a new `buildx` command to utilise Docker's multi-platorm building capability to build and push (!!!) both images.

This is separate from the `build` command as since one of the arch's will be compiled under emulation, and therefore `buildx` can take a long time to complete (took ~2h on my 8 core old gaming laptop).

Some other things added along the way:

* Makefile take REPOSITORY and TAG arguments, such that building local images and testing is easier to do.

Out of scope:

* Haven't integrated it with GitHub actions, as I'm not that familiar with it, but figured this was a good first step.

Known issues:

* For arm64 images, can't get linux-musl test in `make test` to pass. Wondering if we need to explicitly install the amd64 version via apt? Have yet to experiment. Cross compiling to `x86_64-apple-darwin` works perfectly though on arm64 host.

Closes #12