### PR TITLE
Linux/Darwin `arm64` cross-compiling support for `x86_64` Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,31 +26,57 @@ buildx:
 
 test:
 	@docker run --rm -it \
-		-v $(PWD):/drone/src \
-		-w /drone/src \
+		-v $(PWD):/root/src \
+		-w /root/src \
 			$(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
-				make test-ci
+				set -eu; make test-ci
 .PHONY: test
 
 test-ci:
-	@echo "Testing cross-compiling application..."
-	@rustc -vV
-	@echo
-	@cd tests/hello-world \
-		&& echo "Compiling application (linux-musl $$(uname -m))..." \
-		&& cargo build --release --target "$$(uname -m)-unknown-linux-musl" \
-		&& du -sh target/$$(uname -m)-unknown-linux-musl/release/helloworld \
-		&& ./target/$$(uname -m)-unknown-linux-musl/release/helloworld \
-		&& echo \
+	echo "Testing cross-compiling application..."
+	rustc -vV
+	echo
+	cd tests/hello-world \
 \
-		&& echo "Compiling application (apple-darwin x86_64)..." \
+		&& if [ "$$(uname -m)" = "x86_64" ]; then \
+			echo "Compiling application (linux-gnu x86_64)..."; \
+			cargo build --release --target x86_64-unknown-linux-gnu; \
+			du -sh target/x86_64-unknown-linux-gnu/release/helloworld; \
+			target/x86_64-unknown-linux-gnu/release/helloworld; \
+			echo; \
+\
+			echo "Compiling application (linux-musl x86_64)..."; \
+			cargo build --release --target x86_64-unknown-linux-musl; \
+			du -sh target/x86_64-unknown-linux-musl/release/helloworld; \
+			target/x86_64-unknown-linux-musl/release/helloworld; \
+			echo; \
+		fi \
+\
+		&& echo "Cross-compiling application (apple-darwin x86_64)..." \
 		&& cargo build --release --target x86_64-apple-darwin \
 		&& du -sh target/x86_64-apple-darwin/release/helloworld \
 		&& echo \
 \
-		&& echo "Compiling application (apple-darwin aarch64)..." \
-                && cargo build --release --target aarch64-apple-darwin \
-                && du -sh target/aarch64-apple-darwin/release/helloworld
+\
+		&& echo "Cross-compiling application (linux-gnu aarch64)..." \
+		&& cargo build --release --target aarch64-unknown-linux-gnu \
+		&& du -sh target/aarch64-unknown-linux-gnu/release/helloworld \
+		&& if [ "$$(uname -m)" = "aarch64" ]; then \
+			target/aarch64-unknown-linux-gnu/release/helloworld; \
+		fi \
+		&& echo \
+\
+		&& echo "Cross-compiling application (linux-musl aarch64)..." \
+		&& cargo build --release --target aarch64-unknown-linux-musl \
+		&& du -sh target/aarch64-unknown-linux-musl/release/helloworld \
+		&& if [ "$$(uname -m)" = "aarch64" ]; then \
+			target/aarch64-unknown-linux-musl/release/helloworld; \
+		fi \
+		&& echo \
+\
+		&& echo "Cross-compiling application (apple-darwin aarch64)..." \
+		&& cargo build --release --target aarch64-apple-darwin \
+		&& du -sh target/aarch64-apple-darwin/release/helloworld
 
 .ONESHELL: test-ci
 

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ test-ci:
 	@rustc -vV
 	@echo
 	@cd tests/hello-world \
-		&& echo "Compiling application (linux-musl x86_64)..." \
-		&& cargo build --release --target x86_64-unknown-linux-musl \
-		&& du -sh target/x86_64-unknown-linux-musl/release/helloworld \
-		&& ./target/x86_64-unknown-linux-musl/release/helloworld \
+		&& echo "Compiling application (linux-musl $$(uname -m))..." \
+		&& cargo build --release --target "$$(uname -m)-unknown-linux-musl" \
+		&& du -sh target/$$(uname -m)-unknown-linux-musl/release/helloworld \
+		&& ./target/$$(uname -m)-unknown-linux-musl/release/helloworld \
 		&& echo \
 		&& echo "Compiling application (apple-darwin x86_64)..." \
 		&& cargo build --release --target x86_64-apple-darwin \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,34 @@
+REPOSITORY ?= joseluisq
+TAG ?= latest
+
+
 build:
 	docker build \
-		-t joseluisq/rust-linux-darwin-builder:latest \
+		-t $(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
 		-f docker/Dockerfile .
 .PHONY: build
+
+
+# Use to build both arm64 and amd64 images at the same time.
+# WARNING! Will automatically push, since multi-platform images are not available locally.
+# Use `REPOSITORY` arg to specify which container repository to push the images to.
+buildx:
+	docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
+	docker buildx create --name darwin-builder --driver docker-container --bootstrap
+	docker buildx use darwin-builder
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--push \
+		-t $(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
+		-f docker/Dockerfile .
+
+.PHONY: buildx
 
 test:
 	@docker run --rm -it \
 		-v $(PWD):/drone/src \
 		-w /drone/src \
-			joseluisq/rust-linux-darwin-builder:latest \
+			$(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
 				make test-ci
 .PHONY: test
 

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,12 @@ test-ci:
 		&& du -sh target/$$(uname -m)-unknown-linux-musl/release/helloworld \
 		&& ./target/$$(uname -m)-unknown-linux-musl/release/helloworld \
 		&& echo \
+\
 		&& echo "Compiling application (apple-darwin x86_64)..." \
 		&& cargo build --release --target x86_64-apple-darwin \
 		&& du -sh target/x86_64-apple-darwin/release/helloworld \
 		&& echo \
+\
 		&& echo "Compiling application (apple-darwin aarch64)..." \
                 && cargo build --release --target aarch64-apple-darwin \
                 && du -sh target/aarch64-apple-darwin/release/helloworld

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,14 @@ test:
 		-v $(PWD):/root/src \
 		-w /root/src \
 			$(REPOSITORY)/rust-linux-darwin-builder:$(TAG) \
-				set -eu; make test-ci
+				bash -c 'set -eu; make test-ci'
 .PHONY: test
 
 test-ci:
-	echo "Testing cross-compiling application..."
-	rustc -vV
-	echo
-	cd tests/hello-world \
+	@echo "Testing cross-compiling application..."
+	@rustc -vV
+	@echo
+	@cd tests/hello-world \
 \
 		&& if [ "$$(uname -m)" = "x86_64" ]; then \
 			echo "Compiling application (linux-gnu x86_64)..."; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ ENV PATH=/root/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/us
 # `--target` to musl so that our users don't need to keep overriding it manually.
 RUN set -eux \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
-    && rustup target add x86_64-unknown-linux-musl \
+    && rustup target add $(uname -m)-unknown-linux-musl \
     && rustup target add armv7-unknown-linux-musleabihf \
     && rustup target add x86_64-apple-darwin \
     && true
@@ -167,9 +167,13 @@ RUN set -eux \
     && true
 
 ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
+    AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_STATIC=1 \
+    AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_STATIC=1 \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
+    PQ_LIB_STATIC_AARCH64_UNKNOWN_LINUX_MUSL=1 \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
+    PG_CONFIG_AARCH64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     LIBZ_SYS_STATIC=1 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux \
         file \
         gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabihf \
+        g++-aarch64-linux-gnu \
         git \
         libbz2-dev \
         libgmp-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,28 +9,6 @@ LABEL version="${VERSION}" \
     description="Use same Docker image for compiling Rust programs for Linux (musl libc) & macOS (osxcross)." \
     maintainer="Jose Quintana <joseluisq.net>"
 
-# Rust stable toolchain
-ARG TOOLCHAIN=stable
-
-# Dependencies
-
-# OpenSSL 1.1.1 - https://www.openssl.org/source/old/1.1.1/
-ARG OPENSSL_VERSION=1.1.1p
-
-# zlib - http://zlib.net/
-ARG ZLIB_VERSION=1.2.12
-
-# libpq - https://ftp.postgresql.org/pub/source/
-ARG POSTGRESQL_VERSION=14.5
-
-# Mac OS X SDK version - https://github.com/joseluisq/macosx-sdks
-ARG OSX_SDK_VERSION=12.3
-ARG OSX_SDK_SUM=3abd261ceb483c44295a6623fdffe5d44fc4ac2c872526576ec5ab5ad0f6e26c
-ARG OSX_VERSION_MIN=10.14
-
-# OS X Cross - https://github.com/tpoechtrager/osxcross
-ARG OSX_CROSS_COMMIT=50e86ebca7d14372febd0af8cd098705049161b9
-
 # Make sure we have basic dev tools for building C libraries. Our goal
 # here is to support the musl-libc builds and Cargo builds needed for a
 # large selection of the most popular crates.
@@ -85,28 +63,19 @@ RUN set -eux \
 # musl-gcc toolchain and for our Rust toolchain.
 ENV PATH=/root/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Install our Rust toolchain and the `musl` target. We patch the
-# command-line we pass to the installer so that it won't attempt to
-# interact with the user or fool around with TTYs. We also set the default
-# `--target` to musl so that our users don't need to keep overriding it manually.
-RUN set -eux \
-    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
-    && rustup target add $(uname -m)-unknown-linux-musl \
-    && rustup target add armv7-unknown-linux-musleabihf \
-    && rustup target add x86_64-apple-darwin \
-    && true
-ADD docker/cargo-config.toml /root/.cargo/config
-
 # Set up a `git credentials` helper for using GH_USER and GH_TOKEN to access
 # private repositories if desired.
-ADD docker/git-credential-ghtoken /usr/local/bin
+COPY docker/git-credential-ghtoken /usr/local/bin
 RUN set -eux \
     && git config --global credential.https://github.com.helper ghtoken \
     && true
 
 # Build a static library version of OpenSSL using musl-libc. This is needed by
 # the popular Rust `hyper` crate.
-#
+
+# OpenSSL 1.1.1 - https://www.openssl.org/source/old/1.1.1/
+ARG OPENSSL_VERSION=1.1.1p
+
 # We point /usr/local/musl/include/linux at some Linux kernel headers (not
 # necessarily the right ones) in an effort to compile OpenSSL 1.1's "engine"
 # component. It's possible that this will cause bizarre and terrible things to
@@ -138,6 +107,10 @@ RUN set -eux \
     && rm -r /tmp/* \
     && true
 
+
+# zlib - http://zlib.net/
+ARG ZLIB_VERSION=1.2.12
+
 RUN set -eux \
     && echo "Building zlib ${ZLIB_VERSION}..." \
     && cd /tmp \
@@ -149,6 +122,10 @@ RUN set -eux \
     && make -j$(nproc) install \
     && rm -r /tmp/* \
     && true
+
+
+# libpq - https://ftp.postgresql.org/pub/source/
+ARG POSTGRESQL_VERSION=14.5
 
 RUN set -eux \
     && echo "Building libpq ${POSTGRESQL_VERSION}..." \
@@ -184,9 +161,16 @@ ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
 # everybody needing to build them manually.)
 
 
+# Mac OS X SDK version - https://github.com/joseluisq/macosx-sdks
+ARG OSX_SDK_VERSION=12.3
+ARG OSX_SDK_SUM=3abd261ceb483c44295a6623fdffe5d44fc4ac2c872526576ec5ab5ad0f6e26c
+ARG OSX_VERSION_MIN=10.14
+
+# OS X Cross - https://github.com/tpoechtrager/osxcross
+ARG OSX_CROSS_COMMIT=50e86ebca7d14372febd0af8cd098705049161b9
+
 # Install OS X Cross
 # A Mac OS X cross toolchain for Linux, FreeBSD, OpenBSD and Android
-
 RUN set -eux \
     && echo "Cloning osxcross..." \
     && git clone https://github.com/tpoechtrager/osxcross.git /usr/local/osxcross \
@@ -220,8 +204,25 @@ RUN set -eux \
     && echo "compiler-rt installed and working successfully!" \
     && true
 
+
+# Rust stable toolchain
+ARG TOOLCHAIN=stable
+
+# Install our Rust toolchain and the `musl` target. We patch the
+# command-line we pass to the installer so that it won't attempt to
+# interact with the user or fool around with TTYs. We also set the default
+# `--target` to musl so that our users don't need to keep overriding it manually.
 RUN set -eux \
-    && echo "Removing osxcross temp files..." \
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
+    && rustup target add $(uname -m)-unknown-linux-musl \
+    && rustup target add armv7-unknown-linux-musleabihf \
+    && rustup target add x86_64-apple-darwin \
+    && rustup target add aarch64-apple-darwin \
+    && true
+COPY docker/cargo-config.toml /root/.cargo/config
+
+RUN set -eux \
+    && echo "Removing temp files..." \
     && rm -rf *~ taballs *.tar.xz \
     && rm -rf /tmp/* \
     && true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,12 +215,13 @@ ARG TOOLCHAIN=stable
 # `--target` to musl so that our users don't need to keep overriding it manually.
 RUN set -eux \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
-    && rustup target add x86_64-unknown-linux-musl \
-    && rustup target add aarch64-unknown-linux-musl \
-    && rustup target add armv7-unknown-linux-musleabihf \
-    && rustup target add aarch64-unknown-linux-gnu \
-    && rustup target add x86_64-apple-darwin \
-    && rustup target add aarch64-apple-darwin \
+    && rustup target add \
+        aarch64-apple-darwin \
+        aarch64-unknown-linux-gnu \
+        aarch64-unknown-linux-musl \
+        armv7-unknown-linux-musleabihf \
+        x86_64-apple-darwin \
+        x86_64-unknown-linux-musl \
     && true
 COPY docker/cargo-config.toml /root/.cargo/config
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN set -eux \
         cmake \
         curl \
         file \
+        gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabihf \
         git \
         libbz2-dev \
@@ -216,6 +217,7 @@ RUN set -eux \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
     && rustup target add $(uname -m)-unknown-linux-musl \
     && rustup target add armv7-unknown-linux-musleabihf \
+    && rustup target add aarch64-unknown-linux-gnu \
     && rustup target add x86_64-apple-darwin \
     && rustup target add aarch64-apple-darwin \
     && true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,7 +215,8 @@ ARG TOOLCHAIN=stable
 # `--target` to musl so that our users don't need to keep overriding it manually.
 RUN set -eux \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN \
-    && rustup target add $(uname -m)-unknown-linux-musl \
+    && rustup target add x86_64-unknown-linux-musl \
+    && rustup target add aarch64-unknown-linux-musl \
     && rustup target add armv7-unknown-linux-musleabihf \
     && rustup target add aarch64-unknown-linux-gnu \
     && rustup target add x86_64-apple-darwin \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,17 +112,23 @@ RUN set -eux \
 # component. It's possible that this will cause bizarre and terrible things to
 # happen. There may be "sanitized" header
 RUN set -eux \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+        amd64) config='';; \
+        arm64) config='-mno-outline-atomics';; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac \
     && echo "Building OpenSSL ${OPENSSL_VERSION}..." \
     && ls /usr/include/linux \
     && mkdir -p /usr/local/musl/include \
     && ln -s /usr/include/linux /usr/local/musl/include/linux \
-    && ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm \
+    && ln -s "/usr/include/$(uname -m)-linux-gnu/asm" /usr/local/musl/include/asm \
     && ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic \
     && cd /tmp \
     && curl -LO "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" \
     && tar xvzf "openssl-${OPENSSL_VERSION}.tar.gz" \
     && cd "openssl-${OPENSSL_VERSION}" \
-    && env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 \
+    && env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY ${config} "linux-$(uname -m)" \
     && env C_INCLUDE_PATH=/usr/local/musl/include/ make depend \
     && env C_INCLUDE_PATH=/usr/local/musl/include/ make -j$(nproc) \
     && make -j$(nproc) install_sw \

--- a/docker/cargo-config.toml
+++ b/docker/cargo-config.toml
@@ -5,6 +5,9 @@ target = "x86_64-unknown-linux-musl"
 [target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin21.4-clang"
 ar = "x86_64-apple-darwin21.4-ar"

--- a/docker/cargo-config.toml
+++ b/docker/cargo-config.toml
@@ -1,5 +1,5 @@
 [build]
-# Target musl-libc by default when running Cargo.
+# Target musl-libc by default when running Cargo
 target = "x86_64-unknown-linux-musl"
 
 [target.armv7-unknown-linux-musleabihf]
@@ -8,3 +8,7 @@ linker = "arm-linux-gnueabihf-gcc"
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin21.4-clang"
 ar = "x86_64-apple-darwin21.4-ar"
+
+[target.aarch64-apple-darwin]
+linker = "arm64e-apple-darwin21.4-clang"
+ar = "arm64e-apple-darwin21.4-ar"

--- a/docker/cargo-config.toml
+++ b/docker/cargo-config.toml
@@ -8,6 +8,9 @@ linker = "arm-linux-gnueabihf-gcc"
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"
+
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin21.4-clang"
 ar = "x86_64-apple-darwin21.4-ar"


### PR DESCRIPTION
Continuing the work done on #13. This PR adds support for cross-compiling Linux/Darwin `arm64` apps from a `x86_64` Docker image.
It also improves Dockerfile layers caching and cross-compilation tests.