### PR TITLE
v1.86.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: Most of Dockerfile and related were borrowed from https://hub.docker.com/r/ekidd/rust-musl-builder
 
-FROM debian:12.10-slim
+FROM debian:12.11-slim
 
 ARG VERSION=0.0.0
 ENV VERSION=${VERSION}
@@ -174,7 +174,7 @@ ARG OSX_SDK_SUM=518e35eae6039b3f64e8025f4525c1c43786cc5cf39459d609852faf091e34be
 ARG OSX_VERSION_MIN=10.14
 
 # OS X Cross - https://github.com/tpoechtrager/osxcross
-ARG OSX_CROSS_COMMIT=d0376b1c368055bd7ce26da97b86b7fbff2814f1
+ARG OSX_CROSS_COMMIT=f873f534c6cdb0776e457af8c7513da1e02abe59
 
 # Install OS X Cross
 # A Mac OS X cross toolchain for Linux, FreeBSD, OpenBSD and Android
@@ -220,7 +220,7 @@ RUN set -eux \
     && true
 
 # Rust stable toolchain
-ARG TOOLCHAIN=1.85.1
+ARG TOOLCHAIN=1.86.0
 
 # Install our Rust toolchain and the `musl` target. We patch the
 # command-line we pass to the installer so that it won't attempt to

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Below are the default toolchains included in the Docker image.
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target x86_64-unknown-linux-musl"
 ```
 
@@ -52,7 +52,7 @@ docker run --rm \
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target x86_64-unknown-linux-gnu"
 ```
 
@@ -62,7 +62,7 @@ docker run --rm \
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target x86_64-apple-darwin"
 ```
 
@@ -74,7 +74,7 @@ docker run --rm \
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target aarch64-unknown-linux-gnu"
 ```
 
@@ -84,7 +84,7 @@ docker run --rm \
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target aarch64-unknown-linux-musl"
 ```
 
@@ -94,7 +94,7 @@ docker run --rm \
 docker run --rm \
     --volume "${PWD}/sample":/root/src \
     --workdir /root/src \
-      joseluisq/rust-linux-darwin-builder:1.85.1 \
+      joseluisq/rust-linux-darwin-builder:1.86.0 \
         sh -c "cargo build --release --target aarch64-apple-darwin"
 ```
 
@@ -107,7 +107,7 @@ It's known that the [`CARGO_HOME`](https://doc.rust-lang.org/cargo/guide/cargo-h
 You can also use the image as a base for your Dockerfile:
 
 ```Dockerfile
-FROM joseluisq/rust-linux-darwin-builder:1.85.1
+FROM joseluisq/rust-linux-darwin-builder:1.86.0
 ```
 
 ### OSXCross
@@ -150,7 +150,7 @@ compile:
 	@docker run --rm -it \
 		-v $(PWD):/app/src \
 		-w /app/src \
-			joseluisq/rust-linux-darwin-builder:1.85.1 \
+			joseluisq/rust-linux-darwin-builder:1.86.0 \
 				make cross-compile
 .PHONY: compile
 
@@ -173,12 +173,12 @@ Just run the makefile `compile` target, then you will see two release binaries `
 
 ```sh
 make compile
-# rustc 1.85.1 (4eb161250 2025-03-15)
+# rustc 1.86.0 (05f9846f8 2025-03-31)
 # binary: rustc
-# commit-hash: 4eb161250e340c8f48f66e2b929ef4a5bed7c181
-# commit-date: 2025-03-15
+# commit-hash: 05f9846f893b09a1be1fc8560e33fc3c815cfecb
+# commit-date: 2025-03-31
 # host: x86_64-unknown-linux-gnu
-# release: 1.85.1
+# release: 1.86.0
 # LLVM version: 19.1.7
 
 # 2. Compiling application (linux-musl x86_64)...


### PR DESCRIPTION
Release `v1.86.0`, which is homologous to [Rust 1.86.0](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/).

__Updates__

- Release `v1.86.0`. PR #35
  - Debian `12.11` - https://www.debian.org/News/2025/20250517
  - tpoechtrager/osxcross@f873f53

[View Docker image tags](https://hub.docker.com/r/joseluisq/rust-linux-darwin-builder/tags?page=1&ordering=last_updated)