### PR TITLE
Refactor local Docker build steps used for testing on CI

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -83,16 +83,13 @@ jobs:
           docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
       -
         name: Tests (base)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: "${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}"
-          shell: bash
-          options: -v ${{ github.workspace }}:/root/src
-          run: |
-            set -eux
-            cat /etc/debian_version
-            uname -a
-            make test-app
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/root/src \
+            ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }} \
+              bash -c 'set -eux; \
+                cat /etc/debian_version; \
+                uname -a; \
+                make test-app'
       -
         name: Push (base)
         uses: docker/build-push-action@v6
@@ -139,7 +136,7 @@ jobs:
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           build-args: |
-            VERSION=0.0.0
+            VERSION=devel-amd64
           push: false
           load: true
           cache-from: |
@@ -152,18 +149,15 @@ jobs:
           docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}
       -
         name: Tests (libs)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: "${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}"
-          shell: bash
-          options: -v ${{ github.workspace }}:/root/src
-          run: |
-            set -eux
-            cat /etc/debian_version
-            uname -a
-            make test-app
-            make test-zlib
-            make test-openssl
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/root/src \
+            "${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}" \
+              bash -c 'set -eux; \
+                cat /etc/debian_version; \
+                uname -a; \
+                make test-app; \
+                make test-zlib; \
+                make test-openssl'
       -
         name: Push (libs)
         uses: docker/build-push-action@v6
@@ -174,7 +168,7 @@ jobs:
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           build-args: |
-            VERSION=0.0.0
+            VERSION=devel-amd64
           push: true
           cache-from: |
             type=gha,scope=devel-libs-amd64
@@ -249,16 +243,13 @@ jobs:
           docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
       -
         name: Tests (base)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: "${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}"
-          shell: bash
-          options: -v ${{ github.workspace }}:/root/src
-          run: |
-            set -eux
-            cat /etc/debian_version
-            uname -a
-            make test-app
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/root/src \
+            "${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}" \
+              bash -c 'set -eux; \
+                cat /etc/debian_version; \
+                uname -a; \
+                make test-app'
       -
         name: Push (base)
         uses: docker/build-push-action@v6
@@ -305,7 +296,7 @@ jobs:
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           build-args: |
-            VERSION=0.0.0
+            VERSION=devel-arm64
           push: false
           load: true
           cache-from: |
@@ -318,18 +309,15 @@ jobs:
           docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}
       -
         name: Tests (libs)
-        uses: addnab/docker-run-action@v3
-        with:
-          image: "${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}"
-          shell: bash
-          options: -v ${{ github.workspace }}:/root/src
-          run: |
-            set -eux
-            cat /etc/debian_version
-            uname -a
-            make test-app
-            make test-zlib
-            make test-openssl
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/root/src \
+            "${{ env.DOCKER_IMAGE }}:${{ steps.meta2.outputs.version }}" \
+              bash -c 'set -eux; \
+                cat /etc/debian_version; \
+                uname -a; \
+                make test-app; \
+                make test-zlib; \
+                make test-openssl;'
       -
         name: Push (libs)
         uses: docker/build-push-action@v6
@@ -340,7 +328,7 @@ jobs:
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           build-args: |
-            VERSION=0.0.0
+            VERSION=devel-arm64
           push: true
           cache-from: |
             type=gha,scope=devel-libs-arm64

--- a/docker/amd64/libs/Dockerfile
+++ b/docker/amd64/libs/Dockerfile
@@ -1,10 +1,11 @@
-FROM joseluisq/rust-linux-darwin-builder:2.0.0-beta.1
+ARG VERSION=2.0.0-beta.1
+
+FROM ghcr.io/joseluisq/rust-linux-darwin-builder:${VERSION}
 
 LABEL version="${VERSION}" \
     description="Docker image for cross-compiling Rust programs for Linux (musl libc) & macOS (osxcross)." \
     maintainer="Jose Quintana <joseluisq.net>"
 
-ARG VERSION=0.0.0
 ENV VERSION=${VERSION}
 
 # zlib - http://zlib.net/

--- a/docker/arm64/libs/Dockerfile
+++ b/docker/arm64/libs/Dockerfile
@@ -1,10 +1,11 @@
-FROM joseluisq/rust-linux-darwin-builder:2.0.0-beta.1
+ARG VERSION=2.0.0-beta.1
+
+FROM ghcr.io/joseluisq/rust-linux-darwin-builder:${VERSION}
 
 LABEL version="${VERSION}" \
     description="Docker image for cross-compiling Rust programs for Linux (musl libc) & macOS (osxcross)." \
     maintainer="Jose Quintana <joseluisq.net>"
 
-ARG VERSION=0.0.0
 ENV VERSION=${VERSION}
 
 # zlib - http://zlib.net/


### PR DESCRIPTION
This PR updates the local Docker build steps for tests to use the proper base `devel-amd64` and `devel-arm64` images, respectively.

It makes sure to run the tests (in particular `devel-libs` variants) using the latest base image changes.

Also, it drops the usage of a deprecated external action utilized for those testing steps.